### PR TITLE
Update for fix

### DIFF
--- a/src/main/assemblies/plugin.xml
+++ b/src/main/assemblies/plugin.xml
@@ -7,7 +7,6 @@
     <includeBaseDirectory>false</includeBaseDirectory>
     <dependencySets>
         <dependencySet>
-            <outputDirectory>elasticsearch</outputDirectory>
             <useProjectArtifact>true</useProjectArtifact>
             <useTransitiveFiltering>true</useTransitiveFiltering>
             <excludes>
@@ -18,7 +17,7 @@
     <fileSets>
         <fileSet>
             <directory>src/main/resources</directory>
-            <outputDirectory>/elasticsearch</outputDirectory>
+            <outputDirectory>/</outputDirectory>
             <includes>
                 <include>plugin-security.policy</include>
                 <include>plugin-descriptor.properties</include>


### PR DESCRIPTION
ERROR: This plugin was built with an older plugin structure. Contact the plugin author to remove the intermediate "elasticsearch" directory within the plugin zip.